### PR TITLE
Add haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,10 @@
+{
+    "name": "hxdsp",
+    "contributors": [
+        "baioc"
+    ],
+    "classPath": "src",
+    "license": "Public",
+    "version": "0.1.0",
+    "releasenote": ""
+}


### PR DESCRIPTION
Adding a haxelib.json allows us to install the library via git (`haxelib git hxdsp https://github.com/baioc/hxdsp`) and use it as any other Haxe library